### PR TITLE
Fix code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/threat_matrix/secrets.py
+++ b/threat_matrix/secrets.py
@@ -80,11 +80,11 @@ def get_secret(secret_name, default=""):
             secret = aws_get_secret(secret_name)
         except RetrieveSecretException as e:
             logging.error(
-                f"Failed retrieving of secret {secret_name}. Error: {e}."
+                f"Failed retrieving secret. Error: {e}."
             )  # lgtm [py/clear-text-logging-sensitive-data]
         except NoCredentialsError as e:
             logging.error(
-                f"Error: {e}. Secret: {secret_name}"
+                f"Error: {e}. Failed to retrieve secret."
             )  # lgtm [py/clear-text-logging-sensitive-data]
 
     return secret


### PR DESCRIPTION
Fixes [https://github.com/khulnasoft/ThreatMatrix/security/code-scanning/6](https://github.com/khulnasoft/ThreatMatrix/security/code-scanning/6)

To fix the problem, we should avoid logging sensitive information directly. Instead, we can log a generic error message that does not include the `secret_name`. This way, we maintain the functionality of logging errors without exposing sensitive data.

- Replace the logging statements that include `secret_name` with more generic messages.
- Ensure that the new log messages still provide enough context to understand that an error occurred without revealing sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
