### PR TITLE
Fix code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/threat_matrix/secrets.py
+++ b/threat_matrix/secrets.py
@@ -80,11 +80,11 @@ def get_secret(secret_name, default=""):
             secret = aws_get_secret(secret_name)
         except RetrieveSecretException as e:
             logging.error(
-                f"Failed retrieving of secret {secret_name}. Error: {e}."
-            )  # lgtm [py/clear-text-logging-sensitive-data]
-        except NoCredentialsError as e:
+                "Failed retrieving of secret. An error occurred."
+            )
+        except NoCredentialsError:
             logging.error(
-                f"Error: {e}. Secret: {secret_name}"
-            )  # lgtm [py/clear-text-logging-sensitive-data]
+                "No credentials error occurred while retrieving secret."
+            )
 
     return secret


### PR DESCRIPTION
Fixes [https://github.com/khulnasoft/ThreatMatrix/security/code-scanning/5](https://github.com/khulnasoft/ThreatMatrix/security/code-scanning/5)

To fix the problem, we should avoid logging sensitive information directly. Instead, we can log a generic error message without including the `secret_name` or the detailed error message `e`. This ensures that sensitive information is not exposed in the logs.

- Replace the logging statements on lines 83 and 87 to avoid including `secret_name` and `e`.
- Use a generic error message that does not reveal sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
