### PR TITLE
Visualizer download button

### DIFF
--- a/api_app/analyzers_manager/models.py
+++ b/api_app/analyzers_manager/models.py
@@ -2,7 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 from logging import getLogger
-from typing import Optional
+from typing import Optional, Union
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
@@ -121,7 +121,7 @@ class MimeTypes(models.TextChoices):
         return mimetype
 
     @classmethod
-    def calculate(cls, file_pointer, file_name) -> str:
+    def calculate(cls, buffer: Union[bytes, str], file_name: str) -> str:
         from magic import from_buffer as magic_from_buffer
 
         mimetype = None
@@ -129,8 +129,9 @@ class MimeTypes(models.TextChoices):
             mimetype = cls._calculate_from_filename(file_name)
 
         if mimetype is None:
-            buffer = file_pointer.read()
-            mimetype = magic_from_buffer(buffer, mime=True)
+            mimetype = magic_from_buffer(
+                buffer.encode() if isinstance(buffer, str) else buffer, mime=True
+            )
             logger.debug(f"mimetype is {mimetype}")
             try:
                 mimetype = cls(mimetype)

--- a/api_app/serializers/job.py
+++ b/api_app/serializers/job.py
@@ -749,7 +749,9 @@ class FileJobSerializer(_AbstractJobCreateSerializer):
         # calculate ``file_mimetype``
         if "file_name" not in attrs:
             attrs["file_name"] = attrs["file"].name
-        attrs["file_mimetype"] = MimeTypes.calculate(attrs["file"], attrs["file_name"])
+        attrs["file_mimetype"] = MimeTypes.calculate(
+            attrs["file"].read(), attrs["file_name"]
+        )
         # calculate ``md5``
         file_obj = attrs["file"].file
         file_obj.seek(0)

--- a/api_app/visualizers_manager/classes.py
+++ b/api_app/visualizers_manager/classes.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Tuple, Type, Union
 
 from django.db.models import QuerySet
 
+from api_app.analyzers_manager.models import MimeTypes
 from api_app.choices import PythonModuleBasePaths
 from api_app.classes import Plugin
 from api_app.models import AbstractReport
@@ -140,6 +141,48 @@ class VisualizableTitle(VisualizableObject):
     def type(self) -> str:
         return "title"
 
+class VisualizableDownload(VisualizableObject):
+
+    def __init__(
+        self,
+        value: str,
+        payload: str,
+        alignment: VisualizableAlignment = VisualizableAlignment.CENTER,
+        size: VisualizableSize = VisualizableSize.S_AUTO,
+        disable: bool = False,
+        copy_text: str = "",
+        description: str = "",
+        add_metadata_in_description: bool = True,
+        link: str = "",
+    ):
+        # assignments
+        super().__init__(size, alignment, disable)
+        self.value = value
+        self.payload = payload
+        self.copy_text = copy_text
+        self.description = description
+        self.add_metadata_in_description = add_metadata_in_description
+        self.link = link
+        # logic
+        self.mimetype = MimeTypes.calculate(
+            self.payload, self.value
+        )  # needed as field from the frontend
+
+    @property
+    def type(self) -> str:
+        return "download"
+
+    @property
+    def attributes(self) -> List[str]:
+        return super().attributes + [
+            "value",
+            "mimetype",
+            "payload",
+            "copy_text",
+            "description",
+            "add_metadata_in_description",
+            "link",
+        ]
 
 class VisualizableBool(VisualizableBase):
     def __init__(


### PR DESCRIPTION
### **User description**
(Please add to the PR name the issue/s that this PR would close if merged by using a [Github](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) keyword. Example: `<feature name>. Closes #999`. If your PR is made by a single commit, please add that clause in the commit too. This is all required to automate the closure of related issues.)

# Description

Please include a summary of the change and link to the related issue.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [ ] I have read and understood the rules about [how to Contribute](https://khulnasoft.github.io/ThreatMatrix-docs/ThreatMatrix/contribute/) to this project
- [ ] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
  - [ ] I strictly followed the documentation ["How to create a Plugin"](https://khulnasoft.github.io/ThreatMatrix-docs/ThreatMatrix/contribute/#how-to-add-a-new-plugin)
  - [ ] [Usage](https://github.com/khulnasoft/docs/blob/main/docs/ThreatMatrix/usage.md) file was updated.
  - [ ] [Advanced-Usage](https://github.com/khulnasoft/docs/blob/main/docs/ThreatMatrix/advanced_usage.md) was updated (in case the plugin provides additional optional configuration).
  - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://khulnasoft.github.io/ThreatMatrix-docs/ThreatMatrix/contribute/#how-to-share-your-plugin-with-the-community))
  - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/khulnasoft/ThreatMatrix/blob/master/tests/api_app/analyzers_manager/test_classes.py).
  - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://khulnasoft.github.io/ThreatMatrix-docs/ThreatMatrix/contribute/#how-to-modify-a-plugin).
  - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://khulnasoft.github.io/ThreatMatrix-docs/ThreatMatrix/usage/#list-of-pre-built-playbooks).
  - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
  - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks.
  - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
  - [ ] I have added that raw JSON sample to the `MockUpResponse` of the `_monkeypatch()` method. This serves us to provide a valid sample for testing.
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/ThreatMatrix/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://khulnasoft.github.io/ThreatMatrix-docs/ThreatMatrix/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/khulnasoft/ThreatMatrix/blob/master/docs/source/Contribute.md)).
- [ ] If the GUI has been modified:
  - [ ] I have a provided a screenshot of the result in the PR.
  - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules

- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the `calculate` method in `models.py` to accept a buffer that can be either bytes or a string, improving flexibility.
- Updated the import statement to include `Union` from the `typing` module.
- Adjusted the logic to handle encoding of the buffer based on its type, ensuring compatibility with the `magic_from_buffer` function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Enhance `calculate` method to support string buffers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_app/analyzers_manager/models.py

<li>Updated import statement to include <code>Union</code>.<br> <li> Modified <code>calculate</code> method to accept <code>buffer</code> as <code>Union[bytes, str]</code>.<br> <li> Adjusted logic to handle <code>buffer</code> encoding based on its type.<br>


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/ThreatMatrix/pull/176/files#diff-0a493c1d5f4ecda08dd5fb892ae2a5cb08bbf4e12605de8c1f7e9144747e9874">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information